### PR TITLE
Fix Image library usage

### DIFF
--- a/lib/src/network/cnn.dart
+++ b/lib/src/network/cnn.dart
@@ -17,7 +17,7 @@ class CNN {
 
   File createImageFromConvolutionMatrix(Image originalImage, Matrix imageRGB) {
     final newImage = Image.fromBytes(originalImage.width, originalImage.height,
-        imageRGB.toList().map((v) => v.toInt()).toList(), Image.RGB);
+        imageRGB.toList().map((v) => v.toInt()).toList(), format: Format.rgb);
     final file = File('assets/new-image.png')
       ..writeAsBytesSync(newImage.getBytes());
     return file;


### PR DESCRIPTION
Fix compilation of lib/src/network/cnn.dart
`line 19 col 37: Too many positional arguments: 3 expected, but 4 found.`